### PR TITLE
Use docker:// URL to specify container image

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ inputs:
 
 runs:
   using: docker
-  image: "registry.opensuse.org/devel/openqa/containers-tw/isotovideo:qemu-x86"
+  image: "docker://registry.opensuse.org/devel/openqa/containers-tw/isotovideo:qemu-x86"
   args:
     - QEMU_NO_KVM=1
     - CASEDIR=.


### PR DESCRIPTION
It looks like the URL is the preferred format even though it works without it in some cases. Meaning users of the action may get an error like `should either be '[path]/Dockerfile' or 'docker://image[:tag]'` even though the action's own workflow works with both.